### PR TITLE
fixed #4 ファイルの先頭にReactをインポートするように変更する

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { render, fireEvent, waitFor, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { App } from './App';

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { useState, useEffect, FC } from 'react';
 import { Header } from './components/Header';
 import { PrefectureCheckboxList } from './components/PrefectureCheckboxList';

--- a/src/components/Graph.test.tsx
+++ b/src/components/Graph.test.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { render } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { Graph } from './Graph';

--- a/src/components/Graph.tsx
+++ b/src/components/Graph.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import HighchartsReact from 'highcharts-react-official';
 import Highcharts, { Options } from 'highcharts';
 import accessibility from 'highcharts/modules/accessibility';

--- a/src/components/Header.test.tsx
+++ b/src/components/Header.test.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { render } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { Header } from './Header';

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { FC } from 'react';
 
 export const Header: FC = () => (

--- a/src/components/PrefectureCheckboxList.test.tsx
+++ b/src/components/PrefectureCheckboxList.test.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { render, fireEvent, waitFor } from '@testing-library/react';
 import { PrefectureCheckboxList } from './PrefectureCheckboxList';
 import '@testing-library/jest-dom';

--- a/src/components/PrefectureCheckboxList.tsx
+++ b/src/components/PrefectureCheckboxList.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { useState, useEffect, FC } from 'react';
 import { fetchPrefectures } from '../api';
 import { Prefecture, PrefectureCheckboxListProps } from '../types';


### PR DESCRIPTION
## Issue番号
#4 

## 対応内容
- [x] ファイルの先頭にReactをインポートするように変更する

## 動作確認
- [x] ブラウザでの挙動（グラフの描画等）に問題がないことの確認
- [x] エディターにてエラーが出なくなったことを確認
<img width="1332" alt="Screenshot 2024-06-09 at 13 44 30" src="https://github.com/Taisei-rgb/resas-population-graph/assets/69156263/305ef19b-2cb8-4128-9005-90e6c551a907">
